### PR TITLE
Remove text auto from .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,6 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+### CRLF scripts would fail on linux
+**/*.sh text eol=lf


### PR DESCRIPTION
Please check that when you check out this that the `.sh` files (`MonkeyLoader/vendor/run_monkeyloader.sh`) have LF ending instead of CRLF :smile:  .... as all files have LF ending for me anyways, can't really test to see that this works...

Fixes https://github.com/ResoniteModdingGroup/MonkeyLoader.GamePacks.Resonite/issues/49