### PR TITLE
Add overridable Authors to Monkeys

### DIFF
--- a/MonkeyLoader/Meta/IAuthorable.cs
+++ b/MonkeyLoader/Meta/IAuthorable.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MonkeyLoader.Meta
+{
+    /// <summary>
+    /// Defines the interface for something with (potentially) dedicated author information.
+    /// </summary>
+    public interface IAuthorable
+    {
+        /// <summary>
+        /// Gets the names of the authors of this authorable item.
+        /// </summary>
+        public IEnumerable<string> Authors { get; }
+
+        /// <summary>
+        /// Determines whether a given <paramref name="name"/>
+        /// is listed as an author for this authorable item.
+        /// </summary>
+        /// <param name="name">The name to check for.</param>
+        /// <returns><c>true</c> if the given <paramref name="name"/> is listed as an author for this authorable item.</returns>
+        public bool HasAuthor(string name);
+    }
+}

--- a/MonkeyLoader/Meta/IMonkey.cs
+++ b/MonkeyLoader/Meta/IMonkey.cs
@@ -35,7 +35,7 @@ namespace MonkeyLoader.Meta
     /// Defines the interface for all (<see cref="EarlyMonkey{TMonkey}">early</see>)
     /// <see cref="Monkey{TMonkey}">monkeys</see>.
     /// </summary>
-    public interface IMonkey : IRun, IShutdown, IComparable<IMonkey>, INestedIdentifiable<Mod>
+    public interface IMonkey : IRun, IShutdown, IComparable<IMonkey>, INestedIdentifiable<Mod>, IAuthorable
     {
         /// <summary>
         /// Gets the name of the assembly this monkey is defined in.

--- a/MonkeyLoader/Meta/Mod.cs
+++ b/MonkeyLoader/Meta/Mod.cs
@@ -20,7 +20,7 @@ namespace MonkeyLoader.Meta
     /// </summary>
     public abstract partial class Mod : IConfigOwner, IShutdown, ILoadedNuGetPackage, IComparable<Mod>,
         INestedIdentifiableOwner<ConfigSection>, INestedIdentifiableOwner<IDefiningConfigKey>,
-        IIdentifiableOwner<Mod, IMonkey>, IIdentifiableOwner<Mod, IEarlyMonkey>
+        IIdentifiableOwner<Mod, IMonkey>, IIdentifiableOwner<Mod, IEarlyMonkey>, IAuthorable
 
     {
         /// <summary>
@@ -41,7 +41,7 @@ namespace MonkeyLoader.Meta
         /// <summary>
         /// Stores the paths to the mod's content files inside the mod's <see cref="FileSystem">FileSystem</see>.
         /// </summary>
-        protected readonly SortedSet<UPath> contentPaths = new();
+        protected readonly SortedSet<UPath> contentPaths = [];
 
         /// <summary>
         /// Stores the dependencies of this mod.
@@ -328,11 +328,12 @@ namespace MonkeyLoader.Meta
         public bool DependsOn(ILoadedNuGetPackage otherPackage) => DependsOn(otherPackage.Identity.Id);
 
         /// <summary>
-        /// Efficiently checks, whether a given name is listed as an author for this mod.
+        /// Efficiently  determines whether the given
+        /// <paramref name="name"/> is listed as an author for this mod.
         /// </summary>
-        /// <param name="author">The name to check for.</param>
-        /// <returns><c>true</c> if the given name is listed as an author for this mod.</returns>
-        public bool HasAuthor(string author) => authors.Contains(author);
+        /// <param name="name">The name to check for.</param>
+        /// <returns><c>true</c> if the given <paramref name="name"/> is listed as an author for this mod.</returns>
+        public bool HasAuthor(string name) => authors.Contains(name);
 
         /// <summary>
         /// Efficiently checks, whether a given tag is listed for this mod.

--- a/MonkeyLoader/Patching/MonkeyBase.cs
+++ b/MonkeyLoader/Patching/MonkeyBase.cs
@@ -25,6 +25,15 @@ namespace MonkeyLoader.Patching
         /// <inheritdoc/>
         public AssemblyName AssemblyName { get; }
 
+        /// <summary>
+        /// Gets the names of the authors of this particular monkey,
+        /// which may differ from the <see cref="Mod.Authors"/>.
+        /// </summary>
+        /// <remarks>
+        /// <i>By default</i>: <c><see cref="Mod">Mod</see>.<see cref="Mod.Authors">Authors</see></c>.
+        /// </remarks>
+        public virtual IEnumerable<string> Authors => _mod.Authors;
+
         /// <inheritdoc/>
         /// <remarks>
         /// <i>By default</i>: <c>false</c>.
@@ -164,6 +173,10 @@ namespace MonkeyLoader.Patching
 
         /// <inheritdoc/>
         public int CompareTo(IMonkey other) => Monkey.AscendingComparer.Compare(this, other);
+
+        /// <inheritdoc/>
+        public bool HasAuthor(string name)
+            => Authors.Any(author => author.Equals(name, StringComparison.InvariantCultureIgnoreCase));
 
         /// <summary>
         /// Runs this monkey to let it patch.<br/>


### PR DESCRIPTION
Add dedicated Authors override option for Monkeys and create interface for authorable items.

The default for Monkeys is the Mod Authors.