### PR TITLE
Make loading & saving configs more resilient

### DIFF
--- a/MonkeyLoader/Configuration/Config.cs
+++ b/MonkeyLoader/Configuration/Config.cs
@@ -222,15 +222,18 @@ namespace MonkeyLoader.Configuration
 
                 try
                 {
-                    using var file = File.OpenWrite(Owner.ConfigPath);
-                    using var streamWriter = new StreamWriter(file);
-                    using var jsonTextWriter = new JsonTextWriter(streamWriter);
-                    jsonTextWriter.Formatting = Formatting.Indented;
-                    _loadedConfig.WriteTo(jsonTextWriter);
+                    var tempPath = Path.ChangeExtension(Owner.ConfigPath, ".temp.json");
 
-                    // I actually cannot believe I have to truncate the file myself
-                    file.SetLength(file.Position);
-                    jsonTextWriter.Flush();
+                    using (var file = File.Open(tempPath, FileMode.Create, FileAccess.Write, FileShare.Read))
+                    {
+                        using var streamWriter = new StreamWriter(file);
+                        using var jsonTextWriter = new JsonTextWriter(streamWriter) { Formatting = Formatting.Indented };
+
+                        _loadedConfig.WriteTo(jsonTextWriter);
+                        jsonTextWriter.Flush();
+                    }
+
+                    File.Replace(tempPath, Owner.ConfigPath, Path.ChangeExtension(Owner.ConfigPath, ".backup.json"));
 
                     Logger.Info(() => $"Saved config in {stopwatch.ElapsedMilliseconds}ms!");
 


### PR DESCRIPTION
This should prevent configs turning into config-sized `NULL` byte filled files.
When saving, the old config is copied to backup file. This file is also attempted to be loaded if the main file fails.
Failed files get moved to a "broken" backup - separately for main and regular backup file.

When neither the main nor the backup can be loaded, the config is reset to defaults rather than fully failing.