### PR TITLE
WIP: Introduce AssemblyLoadStrategy, support AssemblyLoadContexts

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <LangVersion>13.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/MonkeyLoader/AssemblyLoadContextLoadStrategy.cs
+++ b/MonkeyLoader/AssemblyLoadContextLoadStrategy.cs
@@ -1,0 +1,57 @@
+﻿#if NET5_0_OR_GREATER
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace MonkeyLoader
+{
+    public class AssemblyLoadContextLoadStrategy : IAssemblyLoadStrategy
+    {
+        private AssemblyLoadContext _assemblyLoadContext;
+        
+        public AssemblyLoadContextLoadStrategy()
+        {
+            _assemblyLoadContext = AssemblyLoadContext.GetLoadContext(typeof(AssemblyLoadContextLoadStrategy).Assembly)!;
+        }
+        
+        public Assembly LoadFile(string assemblyPath)
+        {
+            Debug.WriteLine($"AssemblyLoadContextLoadStrategy: Loading assembly from path: {assemblyPath}");
+            
+            // Hack: Check if we already have a DLL with this name loaded and return it if so
+            // This is not correct, but it works for now, we need to have the game in a separate load context in the future
+            // Concretely, both ML and Reso use Mono.Cecil at different versions
+            var loadedAssembly = _assemblyLoadContext.Assemblies
+                .FirstOrDefault(a => !string.IsNullOrEmpty(a.Location) && Path.GetFileName(a.Location) == Path.GetFileName(assemblyPath));
+            if (loadedAssembly != null)
+            {
+                Debug.WriteLine($"=> Found already loaded assembly: {loadedAssembly.FullName}");
+                return loadedAssembly;
+            }
+            
+            if (string.IsNullOrEmpty(assemblyPath))
+            {
+                throw new ArgumentException("Assembly path cannot be null or empty.", nameof(assemblyPath));
+            }
+
+            return _assemblyLoadContext.LoadFromAssemblyPath(assemblyPath);
+        }
+
+        public Assembly Load(byte[] assemblyBytes, byte[]? pdbBytes = null)
+        {
+            Debug.WriteLine("AssemblyLoadContextLoadStrategy: Loading assembly from byte array.");
+            if (assemblyBytes == null || assemblyBytes.Length == 0)
+            {
+                throw new ArgumentException("Assembly bytes cannot be null or empty.", nameof(assemblyBytes));
+            }
+
+            return _assemblyLoadContext.LoadFromStream(new MemoryStream(assemblyBytes),
+                pdbBytes != null ? new  MemoryStream(pdbBytes) : null);
+        }
+    }
+}
+
+#endif

--- a/MonkeyLoader/IAssemblyLoadStrategy.cs
+++ b/MonkeyLoader/IAssemblyLoadStrategy.cs
@@ -1,0 +1,11 @@
+﻿using System.Reflection;
+
+namespace MonkeyLoader
+{
+    public interface IAssemblyLoadStrategy
+    {
+        public Assembly LoadFile(string assemblyPath);
+        
+        public Assembly Load(byte[] assemblyBytes, byte[]? pdbBytes = null);
+    }
+}

--- a/MonkeyLoader/Meta/DynamicMod.cs
+++ b/MonkeyLoader/Meta/DynamicMod.cs
@@ -7,7 +7,9 @@ using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Reflection;
 using Zio;
 using Zio.FileSystems;
 
@@ -51,6 +53,12 @@ namespace MonkeyLoader.Meta
 
         /// <inheritdoc/>
         public override string Title => _title ?? base.Title;
+
+        public override bool TryResolveAssembly(AssemblyName assemblyName, [NotNullWhen(true)] out Assembly? assembly)
+        {
+            assembly = null;
+            return false;
+        }
 
         private DynamicMod(MonkeyLoader loader, Builder builder)
             : base(loader, builder.Location, builder.IsGamePack)

--- a/MonkeyLoader/Meta/Mod.cs
+++ b/MonkeyLoader/Meta/Mod.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Zio;
 
 namespace MonkeyLoader.Meta
@@ -310,6 +311,8 @@ namespace MonkeyLoader.Meta
             _monkeyToggles = new(() => Config.LoadSection(new MonkeyTogglesConfigSection(this)));
         }
 
+        public abstract bool TryResolveAssembly(AssemblyName assemblyName, [NotNullWhen(true)] out Assembly? assembly);
+        
         /// <summary>
         /// Compares this mod with another and returns a value indicating whether
         /// one is dependent on the other, independent, or the other dependent on this.


### PR DESCRIPTION
This PR introduces "assembly load strategies" that abstract how ML loads assemblies into the runtime. This is necessary as ML needs to be the ultimate authority on what assemblies the game resolves - Assembly.LoadFile and others create a separate load context for every call, making it easy for us to get into a situation where we have multiple versions of assemblies loaded that are not compatible.

This approach, as is, has some flaws:
1. ML needs to dual-target netstandard2.0 and net9.0 to use AssemblyLoadContext APIs. This also fixes the issue where we have the wrong Harmony that does not support the .NET9 CLR, but it breaks the zipping workflow and I haven't looked at that yet.
2. We currently just plainly resolve assemblies out of the context using their assembly name, without doing version matching, which is not correct - this is necessary because ML and Reso use Mono.Cecil, but at different versions. The correct approach would be to have two load contexts, one that contains all of the game assemblies, and one that contains all ML-specific dependencies. But this is fine for now I think.

Additionally, I haven't implemented a load strategy that uses Assembly.LoadX for backwards-compatibility with netstandard2.0 yet. This does get us in-game at full speed in Reso though.